### PR TITLE
fix bugs in undeploy, rm redundant maxP from HEFT algorithm

### DIFF
--- a/src/main/java/at/ac/tuwien/ec/scheduling/offloading/OffloadScheduling.java
+++ b/src/main/java/at/ac/tuwien/ec/scheduling/offloading/OffloadScheduling.java
@@ -135,7 +135,7 @@ public class OffloadScheduling extends Scheduling{
      * @param I the target infrastructure
      */
     public void removeCost(MobileSoftwareComponent s, ComputationalNode n, MobileCloudInfrastructure I){
-    	this.userCost -= n.computeCost(s, I.getMobileDevices().get(s.getUserId()), I);
+        this.userCost -= n.computeCost(s, I);
     }
 
     /**
@@ -181,7 +181,7 @@ public class OffloadScheduling extends Scheduling{
 		{
 			//energy is calculated according to the energy model of the node
 			double energy = n.getCPUEnergyModel().computeCPUEnergy(s, n, i);
-			((MobileDevice)i.getNodeById(s.getUserId())).removeFromBudget(energy);
+			((MobileDevice)i.getNodeById(s.getUserId())).addToBudget(energy);
 			this.batteryLifetime += energy;
 		}
 		else
@@ -190,7 +190,7 @@ public class OffloadScheduling extends Scheduling{
 			 * the energy required to offload the task on the network
 			 */
 			double offloadEnergy = i.getMobileDevices().get(s.getUserId()).getNetEnergyModel().computeNETEnergy(s, n, i);
-			i.getMobileDevices().get(s.getUserId()).removeFromBudget(offloadEnergy);
+			i.getMobileDevices().get(s.getUserId()).addToBudget(offloadEnergy);
 			//we remove consumption for task execution to the consumption of the infrastructure (useful in some scenarios)
 			this.infEnergyConsumption -= n.getCPUEnergyModel().computeCPUEnergy(s, n, i);
 			this.batteryLifetime += offloadEnergy;

--- a/src/main/java/at/ac/tuwien/ec/scheduling/offloading/algorithms/heftbased/HEFTResearch.java
+++ b/src/main/java/at/ac/tuwien/ec/scheduling/offloading/algorithms/heftbased/HEFTResearch.java
@@ -103,17 +103,12 @@ public class HEFTResearch extends OffloadScheduler {
 				
 			}
 			else
-			{
-				double maxP = Double.MIN_VALUE;     // maxP: maximum runtime among currTask predecessors 
-				for(MobileSoftwareComponent cmp : currentApp.getPredecessors(currTask))
-					if(cmp.getRunTime()>maxP)
-						maxP = cmp.getRunTime();
-				
+			{		
 				for(ComputationalNode cn : currentInfrastructure.getAllNodes())
-					if(maxP + currTask.getRuntimeOnNode(cn, currentInfrastructure) < tMin &&
+					if(currTask.getRuntimeOnNode(cn, currentInfrastructure) < tMin &&
 							isValid(scheduling,currTask,cn))
 					{
-						tMin = maxP + currTask.getRuntimeOnNode(cn, currentInfrastructure); // Earliest Finish Time  EFT = wij + EST
+						tMin = currTask.getRuntimeOnNode(cn, currentInfrastructure); // Earliest Finish Time  EFT = wij + EST
 						target = cn;
 					}
 				


### PR DESCRIPTION
The maxP value in the HEFT algorithm is redundant, it's just a constant added to all runtimes and will thus have no effect on which ComputationalNode yields the minimum.

OffloadScheduling had some bugs that led to issues when undeploying a task.